### PR TITLE
CORE-473: hotfix/CORE-473-add-api-helm-deploy

### DIFF
--- a/ruby-alpine-node/Dockerfile
+++ b/ruby-alpine-node/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2.5.1
+
+RUN apt-get update -qq && \
+		apt-get install -y build-essential \
+		git \
+		libcurl4-openssl-dev \
+		nodejs \
+		mysql-client \
+		default-libmysqlclient-dev \
+		graphicsmagick \
+		wkhtmltopdf \
+		&& rm -rf /var/lib/apt/lists/* && \
+		curl -L -o /usr/bin/chamber https://github.com/segmentio/chamber/releases/download/v2.3.2/chamber-v2.3.2-darwin-amd64 && \
+		chmod +x /usr/bin/chamber
+


### PR DESCRIPTION
**What Was Implemented**
* Adds Dockerfile for ruby-alpine-node.
* This Dockerfile used to live in [ActivePipe/ruby-alpine-node](https://github.com/ActivePipe/ruby-alpine-node) which can potentially be deleted once this PR has been merged.

**Related Pull Requests**
* https://github.com/ActivePipe/api.activepipe.com/pull/2771
* https://github.com/ActivePipe/k8s-aws/pull/26
* https://github.com/ActivePipe/k8s-charts/pull/11

**Related JIRA Tickets**
* https://thedigitalgroup.atlassian.net/browse/SO-1147